### PR TITLE
User account route rework

### DIFF
--- a/src/controllers/account.js
+++ b/src/controllers/account.js
@@ -1,4 +1,7 @@
+const { update } = require("lodash");
+
 module.exports = [
+  "_",
   "bcrypt",
   "accountRepository",
   "profileRepository",
@@ -8,6 +11,7 @@ module.exports = [
   "errors",
   "utils",
   (
+    _,
     bcrypt,
     accountRepository,
     profileRepository,
@@ -31,7 +35,6 @@ module.exports = [
           const projection = {
             tokens: 0,
             password: 0,
-            _id: 0,
             __v: 0,
           };
 
@@ -48,65 +51,63 @@ module.exports = [
           next(error);
         }
       },
-      create: async (req, res, next) => {
-        try {
-          if (!req.body.password || !isValidPassword(req.body.password)) {
-            const error = new Error(errorCodes.INVALID_PASSWORD);
-            error.name = errorCodes.INVALID_PASSWORD;
-            throw error;
-          }
-
-          if (
-            !isValid(req.body, accountRepository.getSchema(), invalid.account)
-          ) {
-            const error = new Error(errorCodes.INVALID_OBJECT);
-            error.name = errorCodes.INVALID_OBJECT;
-            throw error;
-          }
-          req.body.password = await bcrypt.hash(req.body.password, 8);
-          const newId = await accountRepository.create({
-            newAccount: {
-              ...req.body,
-            },
-          });
-
-          await relationshipsRepository.create(newId);
-          await groupsRepository.create(newId);
-
-          const token = await generateToken(newId);
-
-          await accountRepository.insertToken(newId, token);
-
-          res.status(codes.CREATED).json({
-            token,
-          });
-        } catch (error) {
-          next(error);
-        }
-      },
 
       update: async (req, res, next) => {
         try {
+          const { newPassword = "", password = "", ...body } = req.body;
+
           if (
-            !isValid(req.body, accountRepository.getSchema(), invalid.account)
+            !isValid(body, accountRepository.getSchema(), invalid.account)
           ) {
             const error = new Error(errorCodes.INVALID_UPDATES);
             error.name = errorCodes.INVALID_UPDATES;
             throw error;
           }
 
-          if (req.body.password) {
-            if (!isValidPassword(req.body.password)) {
+          const curr = await accountRepository.get({
+            query: {
+              _id: req.auth.id,
+            },
+            projection: {
+              tokens: 0,
+              _id: 0,
+              discriminator: 0,
+            },
+            lean: true,
+          });
+
+          const currPassword = curr.password;
+          delete curr.password;
+
+          const unchanged = _.isEqual(body, curr);
+          const empty = _.isEmpty(body);
+
+          if ((unchanged || empty) && !newPassword) {
+            return res.send();
+          }
+
+          const match = await bcrypt.compare(password, currPassword);
+
+          const updates = { ...body };
+
+          if (!match) {
+            const error = new Error(errorCodes.PASSWORD_MISMATCH);
+            error.name = errorCodes.PASSWORD_MISMATCH;
+            throw error;
+          }
+
+          if (newPassword) {
+            if (!isValidPassword(newPassword)) {
               const error = new Error(errorCodes.INVALID_PASSWORD);
               error.name = errorCodes.INVALID_PASSWORD;
               throw error;
             }
 
-            req.body.password = await bcrypt.hash(req.body.password, 8);
+            updates.password = await bcrypt.hash(newPassword, 8);
           }
 
           await accountRepository.update({
-            updates: req.body,
+            updates,
             query: { _id: req.auth.id },
           });
           res.send();

--- a/src/controllers/account.js
+++ b/src/controllers/account.js
@@ -35,7 +35,6 @@ module.exports = [
           const projection = {
             tokens: 0,
             password: 0,
-            __v: 0,
           };
 
           const opts = {

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -1,0 +1,117 @@
+module.exports = [
+  "bcrypt",
+  "accountRepository",
+  "profileRepository",
+  "relationshipsRepository",
+  "groupsRepository",
+  "httpStatus",
+  "errors",
+  "utils",
+  (
+    bcrypt,
+    accountRepository,
+    profileRepository,
+    relationshipsRepository,
+    groupsRepository,
+    httpStatus,
+    errors,
+    utils
+  ) => {
+    const codes = httpStatus.statusCodes;
+    const errorCodes = errors.errorCodes;
+    const { isValid, invalid, isValidPassword, generateToken } = utils;
+
+    return {
+      get: async (req, res, next) => {
+        try {
+          const accountQuery = {
+            _id: req.params.id,
+          };
+
+          const accounProjection = {
+            tokens: 0,
+            password: 0,
+          };
+
+          const accountOpts = {
+            query: accountQuery,
+            projection: accounProjection,
+            lean: true,
+          };
+
+          const account = await accountRepository.get(accountOpts);
+
+          const profileQuery = {
+            account: req.params.id,
+          };
+
+          const profileProjection = {
+            _id: 0,
+            __v: 0,
+            age: 0,
+            name: 0,
+          };
+
+          const profiletOpts = {
+            query: profileQuery,
+            projection: profileProjection,
+            lean: true,
+          };
+
+          const profile = await profileRepository.get(profiletOpts);
+
+          const id = account._id;
+
+          delete account._id;
+
+          const returnVal = {
+            id,
+            account,
+            profile,
+          };
+
+          res.json(returnVal || {});
+        } catch (error) {
+          console.log(error);
+          next(error);
+        }
+      },
+      create: async (req, res, next) => {
+        try {
+          if (!req.body.password || !isValidPassword(req.body.password)) {
+            const error = new Error(errorCodes.INVALID_PASSWORD);
+            error.name = errorCodes.INVALID_PASSWORD;
+            throw error;
+          }
+
+          if (
+            !isValid(req.body, accountRepository.getSchema(), invalid.account)
+          ) {
+            const error = new Error(errorCodes.INVALID_OBJECT);
+            error.name = errorCodes.INVALID_OBJECT;
+            throw error;
+          }
+          req.body.password = await bcrypt.hash(req.body.password, 8);
+          const newId = await accountRepository.create({
+            newAccount: {
+              ...req.body,
+            },
+          });
+
+          await relationshipsRepository.create(newId);
+          await groupsRepository.create(newId);
+
+          const token = await generateToken(newId);
+
+          await accountRepository.insertToken(newId, token);
+
+          res.status(codes.CREATED).json({
+            token,
+          });
+        } catch (error) {
+          next(error);
+        }
+      },
+    };
+  },
+];

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -41,6 +41,14 @@ module.exports = [
 
           const account = await accountRepository.get(accountOpts);
 
+          
+
+          if (!account) {
+            const error = new Error(errorCodes.USER_DOES_NOT_EXIST);
+            error.name = errorCodes.USER_DOES_NOT_EXIST;
+            throw error;
+          }
+
           const profileQuery = {
             account: req.params.id,
           };
@@ -58,7 +66,7 @@ module.exports = [
             lean: true,
           };
 
-          const profile = await profileRepository.get(profiletOpts);
+          const profile = (await profileRepository.get(profiletOpts)) || {};
 
           const id = account._id;
 
@@ -70,9 +78,10 @@ module.exports = [
             profile,
           };
 
+          console.log(returnVal)
+
           res.json(returnVal || {});
         } catch (error) {
-          console.log(error);
           next(error);
         }
       },

--- a/src/repositories/account.js
+++ b/src/repositories/account.js
@@ -17,7 +17,7 @@ module.exports = [
     const get = async (opts) => {
       const account = await accountModel
         .findOne(opts.query)
-        .select(opts.projection)
+        .select({ __v: 0, ...opts.projection })
         .lean(opts.lean);
       return account;
     };
@@ -30,10 +30,6 @@ module.exports = [
       updates.forEach((update) => {
         account[update] = opts.updates[update];
       });
-
-      if (account.isDirectModified("password")) {
-        account.password = await bcrypt.hash(account.password, 8);
-      }
 
       await account.save();
     };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,22 +1,16 @@
 const express = require("express");
 
 module.exports = [
+  "usersRoute",
   "profileRoute",
   "messageRoute",
-  "accountRoute",
   "authRoute",
   "relationshipsRoute",
-  (
-    profileRoute,
-    messageRoute,
-    accountRoute,
-    authRoute,
-    relationshipsRoute
-  ) => {
+  (usersRoute, profileRoute, messageRoute, authRoute, relationshipsRoute) => {
     const router = new express.Router();
 
+    router.use("/users", usersRoute);
     router.use("/profile", profileRoute);
-    router.use("/account", accountRoute);
     router.use("/auth", authRoute);
     router.use("/relationships", relationshipsRoute);
     router.use("/message", messageRoute);

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -1,0 +1,18 @@
+const express = require("express");
+
+module.exports = [
+  "usersController",
+  "meRoute",
+  (usersController, meRoute) => {
+    const router = new express.Router();
+
+    // /user routes
+    router.post("/", usersController.create);
+    router.get("/:id", usersController.get);
+
+    // /user/me routes
+    router.use("/me", meRoute);
+
+    return router;
+  },
+];

--- a/src/routes/users/me.js
+++ b/src/routes/users/me.js
@@ -1,0 +1,13 @@
+const express = require("express");
+
+module.exports = [
+  "accountRoute",
+  (accountRoute) => {
+    const router = new express.Router();
+
+    // /account
+    router.use("/account", accountRoute);
+
+    return router;
+  },
+];

--- a/src/routes/users/routes/account.js
+++ b/src/routes/users/routes/account.js
@@ -7,7 +7,6 @@ module.exports = [
     const router = new express.Router();
 
     router.get("/", auth, accountController.get);
-    router.post("/", accountController.create);
     router.put("/", auth, accountController.update);
     router.delete("/", auth, accountController.delete);
 

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ container.register("TOKEN_LIFE_TIME", +process.env.TOKEN_LIFE_TIME || 15000);
 container.register("MAX_ALLOWED", +process.env.MAX_ALLOWED || 10000);
 
 //packages
+container.register("_", require("lodash"));
 container.register("bcrypt", require("bcrypt"));
 container.register("jsonwebtoken", require("jsonwebtoken"));
 
@@ -52,6 +53,7 @@ container.factory("msgRepository", require("./repositories/message"));
 
 //controllers
 container.factory("profileController", require("./controllers/profile"));
+container.factory("usersController", require("./controllers/users"));
 container.factory("accountController", require("./controllers/account"));
 container.factory("authController", require("./controllers/auth"));
 container.factory(
@@ -61,9 +63,11 @@ container.factory(
 container.factory("msgController", require("./controllers/message"));
 
 //routes
-container.factory("routes", require("./routes/root"));
+container.factory("routes", require("./routes/"));
+container.factory("usersRoute", require("./routes/users"));
+container.factory("meRoute", require("./routes/users/me"));
 container.factory("profileRoute", require("./routes/profile"));
-container.factory("accountRoute", require("./routes/account"));
+container.factory("accountRoute", require("./routes/users/routes/account"));
 container.factory("relationshipsRoute", require("./routes/relationships"));
 container.factory("authRoute", require("./routes/auth"));
 container.factory("messageRoute", require("./routes/message"));

--- a/src/utils/error/errors.js
+++ b/src/utils/error/errors.js
@@ -14,6 +14,10 @@ module.exports = [
       status: codes.UNAUTHORIZED,
       message: "Unable to login",
     };
+    errorInfo[(errorCodes.PASSWORD_MISMATCH = "PasswordMismatchError")] = {
+      status: codes.UNAUTHORIZED,
+      message: "Password does not match.",
+    };
     errorInfo[(errorCodes.PLEASE_AUTHENTICATE = "PleaseAuthenticateError")] = {
       status: codes.UNAUTHORIZED,
       message: "Please log in",

--- a/tests/Unit/controllers/account.test.js
+++ b/tests/Unit/controllers/account.test.js
@@ -167,7 +167,7 @@ describe("Account Controller tests", () => {
       accountRepository.update = jest.fn();
     });
 
-    test("Should update successfully when the password matches and their is changes ", async () => {
+    test("Should update successfully when the password matches and there is changes ", async () => {
       const req = {
         body: {
           ...expectedUpdates,

--- a/tests/Unit/controllers/users.test.js
+++ b/tests/Unit/controllers/users.test.js
@@ -1,0 +1,344 @@
+const usersFactory = require("../../../src/controllers/users");
+const getUsersController = usersFactory[usersFactory.length - 1];
+
+const errorsFactory = require("../../../src/utils/error/errors");
+const getErrorsController = errorsFactory[errorsFactory.length - 1];
+
+const httpStatus = require("../../../src/utils/httpStatus");
+const errors = getErrorsController(httpStatus);
+
+const errorCodes = errors.errorCodes;
+const statusCodes = httpStatus.statusCodes;
+
+const email = "test@test.com";
+const password = "password";
+const userName = "test";
+
+const expectedEncryptedPassword = "encrypted password";
+const expectedSchema = {
+  field1: "some value",
+};
+const expectedToken = "adfa8324adradf";
+const expectedAccountId = "asd2123";
+
+const expectedAccount = {
+  userName,
+  email,
+};
+
+const expectedProfile = {
+  status: "Some status",
+  statusMessage: "Some status message",
+  language: "Some language",
+};
+
+const newAccount = {
+  userName,
+  email,
+  password,
+};
+
+const unknownError = new Error(errorCodes.UNKNOWN);
+unknownError.name = errorCodes.UNKNOWN;
+
+describe("Users controller tests", () => {
+  let bcrypt = {};
+  let accountRepository = {};
+  let profileRepository = {};
+  let relationshipsRepository = {};
+  let groupsRepository = {};
+  let utils = {};
+  let controller = null;
+  let next = jest.fn();
+
+  beforeEach(() => {
+    bcrypt = {};
+    accountRepository = {};
+    profileRepository = {};
+    relationshipsRepository = {};
+    groupsRepository = {};
+    utils = {};
+
+    bcrypt.hash = jest.fn(() => expectedEncryptedPassword);
+
+    accountRepository.getSchema = jest.fn(() => {
+      return expectedSchema;
+    });
+    accountRepository.insertToken = jest.fn();
+    accountRepository.get = jest.fn(() => {
+      return {
+        _id: expectedAccountId,
+        ...expectedAccount,
+      };
+    });
+    profileRepository.get = jest.fn(() => {
+      return expectedProfile;
+    });
+    utils.generateToken = jest.fn(() => expectedToken);
+    utils.invalid = {
+      account: ["field1"],
+    };
+    utils.isValidPassword = jest.fn(() => true);
+    utils.isValid = jest.fn(() => true);
+
+    next = jest.fn();
+
+    controller = getUsersController(
+      bcrypt,
+      accountRepository,
+      profileRepository,
+      relationshipsRepository,
+      groupsRepository,
+      httpStatus,
+      errors,
+      utils
+    );
+  });
+
+  describe("Get user", () => {
+    const expectedAccountQuery = {
+      _id: expectedAccountId,
+    };
+
+    const expectedAccountPojection = {
+      tokens: 0,
+      password: 0,
+    };
+
+    const expectedAccountOpts = {
+      query: expectedAccountQuery,
+      projection: expectedAccountPojection,
+      lean: true,
+    };
+
+    const expectedProfileQuery = {
+      account: expectedAccountId,
+    };
+
+    const expectedProfileProjection = {
+      _id: 0,
+      __v: 0,
+      age: 0,
+      name: 0,
+    };
+
+    const expectedProfiletOpts = {
+      query: expectedProfileQuery,
+      projection: expectedProfileProjection,
+      lean: true,
+    };
+
+    const req = {
+      params: {
+        id: expectedAccountId,
+      },
+    };
+
+    const res = {
+      json: jest.fn(),
+    };
+
+    test("Should return user account", async () => {
+      await controller.get(req, res, next);
+
+      expect(accountRepository.get).toBeCalledWith(expectedAccountOpts);
+      expect(profileRepository.get).toBeCalledWith(expectedProfiletOpts);
+      expect(res.json).toBeCalledWith({
+        id: expectedAccountId,
+        account: expectedAccount,
+        profile: expectedProfile,
+      });
+    });
+    test("Should handle errors", async () => {
+      accountRepository.get = jest.fn(() => {
+        throw unknownError;
+      });
+
+      const expectedQuery = {
+        _id: expectedAccountId,
+      };
+
+      const expectedPojection = {
+        tokens: 0,
+        password: 0,
+      };
+
+      const expectedOpts = {
+        query: expectedQuery,
+        projection: expectedPojection,
+        lean: true,
+      };
+
+      const req = {
+        params: {
+          id: expectedAccountId,
+        },
+      };
+
+      const res = {
+        json: jest.fn(),
+      };
+
+      await controller.get(req, res, next);
+
+      expect(accountRepository.get).toBeCalledWith(expectedOpts);
+      expect(res.json).toHaveBeenCalledTimes(0);
+      expect(next).toBeCalledWith(unknownError);
+    });
+  });
+
+  describe("Create account", () => {
+    test("Should create account successfully and return token given correct input", async () => {
+      const expectedNewAccount = {
+        ...newAccount,
+        password: expectedEncryptedPassword,
+      };
+
+      const req = {
+        body: { ...newAccount },
+      };
+
+      const res = {
+        status: jest.fn(() => {
+          return res;
+        }),
+        json: jest.fn(() => {
+          return res;
+        }),
+      };
+
+      accountRepository.create = jest.fn((opts) => {
+        return expectedAccountId;
+      });
+
+      relationshipsRepository.create = jest.fn();
+
+      groupsRepository.create = jest.fn();
+
+      await controller.create(req, res, next);
+
+      expect(utils.isValidPassword).toBeCalledWith(password);
+      expect(utils.isValid).toBeCalledWith(
+        req.body,
+        expectedSchema,
+        utils.invalid.account
+      );
+      expect(bcrypt.hash).toBeCalledWith(password, 8);
+      expect(accountRepository.create).toBeCalledWith({
+        newAccount: expectedNewAccount,
+      });
+      expect(relationshipsRepository.create).toBeCalledWith(expectedAccountId);
+      expect(groupsRepository.create).toBeCalledWith(expectedAccountId);
+      expect(utils.generateToken).toBeCalledWith(expectedAccountId);
+      expect(accountRepository.insertToken).toBeCalledWith(
+        expectedAccountId,
+        expectedToken
+      );
+      expect(res.status).toBeCalledWith(statusCodes.CREATED);
+      expect(res.json).toBeCalledWith({ token: expectedToken });
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    test("Should throw invalid object error when request contains invalid falids and handle it", async () => {
+      const expectedError = new Error(errorCodes.INVALID_OBJECT);
+      expectedError.name = errorCodes.INVALID_OBJECT;
+      const expectedSchema = {
+        field1: "some value",
+      };
+
+      const req = {
+        body: {
+          ...newAccount,
+        },
+      };
+      const res = {};
+
+      utils.isValid = jest.fn(() => false);
+
+      controller = getUsersController(
+        bcrypt,
+        accountRepository,
+        profileRepository,
+        relationshipsRepository,
+        groupsRepository,
+        httpStatus,
+        errors,
+        utils
+      );
+
+      await controller.create(req, res, next);
+      expect(utils.isValidPassword).toBeCalledWith(password);
+      expect(utils.isValid).toBeCalledWith(
+        req.body,
+        expectedSchema,
+        utils.invalid.account
+      );
+      expect(next).toBeCalledWith(expectedError);
+    });
+
+    test("Should throw invalid password error when request contains invalid password and handle it", async () => {
+      const expectedError = new Error(errorCodes.INVALID_PASSWORD);
+      expectedError.name = errorCodes.INVALID_PASSWORD;
+
+      const req = {
+        body: {
+          ...newAccount,
+        },
+      };
+      const res = {};
+      const next = jest.fn();
+
+      utils.isValidPassword = jest.fn(() => false);
+
+      controller = getUsersController(
+        bcrypt,
+        accountRepository,
+        profileRepository,
+        relationshipsRepository,
+        groupsRepository,
+        httpStatus,
+        errors,
+        utils
+      );
+
+      await controller.create(req, res, next);
+      expect(utils.isValidPassword).toBeCalledWith(password);
+      expect(next).toBeCalledWith(expectedError);
+    });
+
+    test("Should handle errors", async () => {
+      const expectedNewAccount = {
+        ...newAccount,
+        password: expectedEncryptedPassword,
+      };
+
+      const expectedSchema = {
+        field1: "some value",
+      };
+
+      accountRepository.create = jest.fn(() => {
+        throw unknownError;
+      });
+
+      const req = {
+        body: {
+          ...newAccount,
+        },
+      };
+      const res = {};
+
+      await controller.create(req, res, next);
+      expect(utils.isValidPassword).toBeCalledWith(password);
+      expect(utils.isValid).toBeCalledWith(
+        req.body,
+        expectedSchema,
+        utils.invalid.account
+      );
+      expect(bcrypt.hash).toBeCalledWith(password, 8);
+      expect(accountRepository.create).toBeCalledWith({
+        newAccount: expectedNewAccount,
+      });
+      expect(next).toBeCalledWith(unknownError);
+    });
+  });
+});


### PR DESCRIPTION
Move create account to users controller, and add new use end points

-Move create account to user controller
-/account -> /users/me/acount
-/users with post creates new user
-/users/:id gets user with id (returns a subset of profile and account)
-updating account will require the current password as well as a token
-updating with no change or no password will perform a no op
-update account controller unit tests
-add user controller unit tests